### PR TITLE
docs: reference MIT license in README (fixes #4)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Mauro
+Copyright (c) 2025 LobbyLeaks Digestor contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-# lobby-leaks
+# LobbyLeaks Digestor
 
 ## ¿Qué es LobbyLeaks Digestor?
-Conoce la misión y métricas en nuestro
+
+Conoce la misión y métricas en nuestro  
 [Project Charter](docs/charter.md).
+
+## License
+
+This project is released under the [MIT License](LICENSE).


### PR DESCRIPTION
Fixes #4 
Linked to #7 