### PR TITLE
docs: update charter for open source release (apr 2026)

### DIFF
--- a/docs/charter.md
+++ b/docs/charter.md
@@ -4,16 +4,16 @@
 
 Empoderar a la ciudadanía mundial, empezando por **Chile**, poniendo en
 un grafo abierto la relación entre lobby oficial, gasto parlamentario y
-financiamiento electoral antes de procesos electorales.
+financiamiento electoral para promover la transparencia y el escrutinio público.
 
 ## Alcance
 
-- **Módulo Chile**: ingestión automática vía API Ley de Lobby, Transparencia
-  Activa y Servel.
+- **Módulo Chile**: ingestión automática vía API Ley de Lobby, InfoLobby SPARQL,
+  Transparencia Activa y Servel.
 - **Modo global**: arquitectura multi‑jurisdicción; cualquier país puede
-  añadir un conector o subir evidencia manual (“Sube tu leak”).
+  añadir un conector o subir evidencia manual ("Sube tu leak").
 - Exponerlos mediante API abierta, UI web y descargas CSV/JSON.
-- Entregar un MVP funcional en 8 semanas (31 ago 2025).
+- Entregar un MVP funcional en abril 2026.
 
 ## Fuera de alcance
 
@@ -23,19 +23,19 @@ financiamiento electoral antes de procesos electorales.
 
 ## Métricas de éxito
 
-| KPI | Fórmula ⚙️ | Línea base <br>25 jun 2025 | Meta <br>+8 semanas | Fuente de medición | Revisión |
-|-----|------------|---------------------------|---------------------|--------------------|----------|
-| **Países integrados** | `jurisdictions.count()` | 1 (CL) | ≥ 2 | DB stats | Cada sprint |
+| KPI | Fórmula ⚙️ | Línea base <br>dic 2025 | Meta <br>abr 2026 | Fuente de medición | Revisión |
+|-----|------------|-------------------------|-------------------|--------------------|----------|
+| **Países integrados** | `jurisdictions.count()` | 1 (CL) | ≥ 2 | DB stats | Cada sprint |
 | **Éxito de ingesta diaria** | `jobs_ok / jobs_tot` | 0 / 0 | ≥ 95 % | Cron monitor (StatusCake) | Cada semana |
 | **Visitantes únicos / semana** | Matomo `Visits > Unique` | 0 | ≥ 500 | Matomo | Cada lunes |
 | **PRs de la comunidad fusionadas** | `PR_merged_community` | 0 | ≥ 3 | GitHub API | Fin de sprint |
 | **Tiempo mediano de proceso PDF ciudadano** | p50 `end-to-end_secs` | — | ≤ 900 s | CloudWatch (λ OCR) | Cada despliegue |
 | **Alertas lobby ↔ aporte emitidas** | `alerts_sent` | 0 | ≥ 20 | Supabase Realtime | Cada sprint |
-> *Fuentes de datos*: Matomo v5 (analytics), GitHub REST v3, Supabase Metrics, StatusCake Cron.  
+> *Fuentes de datos*: Matomo v5 (analytics), GitHub REST v3, Supabase Metrics, StatusCake Cron.
 > *Cadencia de revisión*: los KPIs se comentan cada sprint (viernes) y se publican en `/docs/kpi-history.md`.
 
 ## Roadmap
 
-Resumen visual del plan de 8 semanas en `/docs/roadmap.png` (auto-generado desde GitHub Projects).
+Resumen visual del plan en `/docs/roadmap.png` (auto-generado desde GitHub Projects).
 
-_Licencia MIT · última edición 25 jun 2026_
+_Licencia MIT · última edición dic 2025_


### PR DESCRIPTION
**Context**: The project originally aimed to launch before Chile's 2025 elections, but that wasn't possible. Now the focus is an open source release in ~4 months.

**Changes**:
- Purpose: from "before electoral processes" → "to promote transparency and public scrutiny"
- Timeline: from "MVP 8 weeks (Aug 31 2025)" → "MVP April 2026"
- Chile sources: added "InfoLobby SPARQL" alongside Ley de Lobby API
- Metrics: baseline updated to Dec 2025

**Why**: The project is no longer tied to a specific electoral event. It's a permanent transparency tool.