### PR TITLE
fix(info_lobby_sync): apellidos NULL + Virtuoso 100k cap

### DIFF
--- a/services/info_lobby_sync/persistence.py
+++ b/services/info_lobby_sync/persistence.py
@@ -436,12 +436,21 @@ def _extract_nombres(full_name: str) -> Optional[str]:
     return full_name
 
 
-def _extract_apellidos(full_name: str) -> Optional[str]:
-    """Extract last name(s) from full name (best effort)."""
+def _extract_apellidos(full_name: str) -> str:
+    """Extract last name(s) from a full name (best effort).
+
+    Returns an empty string for single-word names instead of None: the
+    Person.apellidos column is NOT NULL in the schema and InfoLobby has
+    a non-trivial number of entities recorded with just a first name
+    (e.g. "Paul", "Catalina"). The first full sync (commit aece0a6) hit
+    NotNullViolation on these and aborted the whole bulk-insert
+    transaction. Returning "" satisfies the constraint without
+    inventing data; downstream consumers can detect the "no last name"
+    case by checking `apellidos == ""`.
+    """
     if not full_name:
-        return None
+        return ""
     parts = full_name.strip().split()
     if len(parts) >= 2:
-        # Assume rest are apellidos
         return " ".join(parts[1:])
-    return None
+    return ""

--- a/services/info_lobby_sync/run_sync.py
+++ b/services/info_lobby_sync/run_sync.py
@@ -74,6 +74,14 @@ KIND_PARSERS = {
     "donativos": parse_all_donativos,
 }
 
+# InfoLobby runs Virtuoso, which caps `ORDER BY ... LIMIT N OFFSET M` queries
+# at M+N <= 100_000 with SR353 ("Sorted TOP clause specifies more then ... rows
+# to sort. Only 100000 are allowed."). Going past this requires keyset
+# pagination (cursor by fechaEvento DESC) — tracked as Phase 2. For now the
+# fetcher clamps each batch so the (offset+limit) stays within bounds and
+# stops cleanly when there's no room left.
+VIRTUOSO_ORDERED_MAX = 100_000
+
 
 def _to_dict(obj: Any) -> dict:
     if is_dataclass(obj):
@@ -123,6 +131,21 @@ def fetch_kind_paginated(
             limit = min(batch_size, remaining)
         else:
             limit = batch_size
+
+        # Clamp so offset+limit stays within Virtuoso's 100k ORDER-BY cap.
+        # When offset >= VIRTUOSO_ORDERED_MAX we can't ask for any more
+        # rows without hitting SR353 — stop cleanly and let the caller
+        # know (the wrapper script reads this as "kind exhausted").
+        if offset >= VIRTUOSO_ORDERED_MAX:
+            logger.info(
+                "fetch %s — hit Virtuoso ORDER BY cap at offset=%d; "
+                "stopping (Phase 2 keyset pagination needed for the rest)",
+                kind, offset,
+            )
+            break
+        room = VIRTUOSO_ORDERED_MAX - offset
+        if limit > room:
+            limit = room
 
         logger.info("fetch %s offset=%d limit=%d (have %d)", kind, offset, limit, len(all_records))
         batch = fetch_fn(client=client, limit=limit, offset=offset)


### PR DESCRIPTION
## Summary

Two bugs that together silently broke the full InfoLobby sync launched in PR #106. Both were latent (pre-existing) and only surfaced when running at corpus scale.

### Bug 1 — `_extract_apellidos` returns None for single-word names

InfoLobby contains real entities with just a first name ("Paul", "Catalina", "Solange", etc.). `Person.apellidos` is `NOT NULL` per schema. The smoke test (limit=10) hit only multi-word names, so this stayed hidden until chunk 1 of the full sync — where the bulk INSERT in `_bulk_upsert_persons` hit `psycopg.IntegrityError` and the whole transaction got `InFailedSqlTransaction`-aborted.

**Fix**: return `""` (not None) for single-word names. Honest semantics ("name exists, no surname"), no migration, no data invention.

### Bug 2 — Virtuoso ORDER BY 100k cap (SR353)

InfoLobby runs on OpenLink Virtuoso, which caps `ORDER BY ... LIMIT N OFFSET M` at `M+N ≤ 100,000` with error SR353. Chunk 2 of the full sync hit this hard (`offset=100_000, limit=1000`), retried 3× (all 500), raised `SPARQLFetchError`, and the wrapper script read the resulting "0 fetched" as "all kinds exhausted" and exited.

**Fix**: clamp `offset+limit ≤ VIRTUOSO_ORDERED_MAX (=100_000)` in `fetch_kind_paginated`. The fetcher now stops cleanly at the cap with an informative log instead of throwing. Wrapper sees a real exhaustion signal.

**Phase 2 (not in this PR)**: keyset pagination (cursor by `fechaEvento DESC` instead of OFFSET) to reach the remaining ~825k audiencias + 694k viajes. Tracked as a follow-up.

## What changes after this merges

Re-running `scripts/sync_infolobby_full.sh` will:
1. Heal the current partially-populated graph (Person=4,688, Organisation=3,582 vs Event=266,749, Edge=135,938) by inserting the ~80k persons + ~85k orgs that chunk 1 dropped due to bug 1.
2. Stop cleanly at the Virtuoso 100k cap per kind (so wrapper exits correctly).
3. Final state: full first-100k of audiencias + viajes + all 67k donativos, fully linked Person/Organisation/Event/Edge — a substantial MVP dataset for Stage 3 API and Stage 4 frontend work.

## Test plan

- [x] AST checks: both files parse
- [x] Smoke test (`scripts/sync_infolobby_smoke.py --limit 10`) green; pipeline still idempotent (run twice → 0 new rows on 2nd run)
- [ ] Post-merge: re-run `sync_infolobby_full.sh`, expect ~80k new persons + ~85k new orgs and final MV refresh
- [ ] Phase 2 (separate PR): keyset pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)